### PR TITLE
Completes localization

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -7,3 +7,7 @@ en:
   label_privacy_display_settings: Display Settings
   label_privacy_displayname_fallback: "Fallback users display format when no display name is set:"
   label_privacy_displayname_info: "This setting is only relevant when the global <em>Users display format</em> is set to use the display name field, which is not the case at the moment. Go to %{link} to change the users display format."
+
+  project_module_privacy: "Privacy"
+  permission_view_users: "View users"
+  permission_view_members_displayname: "View member's display name"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -5,5 +5,9 @@ ja:
   field_warn_when_creating_public_issue: 公開レポートを作成する前に警告する
   text_privacy_confirm_public: 本当に公開レポートを作成したいですか？
   label_privacy_display_settings: 表示設定
-  label_privacy_displayname_fallback: "Fallback users display format when no display name is set:"
-  label_privacy_displayname_info: "This setting is only relevant when the global <em>Users display format</em> is set to use the display name field, which is not the case at the moment. Go to %{link} to change the users display format."
+  label_privacy_displayname_fallback: "表示名が設定されていない場合、ユーザーの表示形式をフォールバックします。"
+  label_privacy_displayname_info: "この設定は、グローバルな<em>ユーザーの表示形式</em>が表示名フィールドを使用するように設定されている場合にのみ関係しますが、現在はそうではありません。ユーザーの表示形式を変更するには、%{link}にアクセスしてください。"
+
+  project_module_privacy: "プライバシー"
+  permission_view_users: "ユーザーの閲覧"
+  permission_view_members_displayname: "メンバーの表示名の閲覧"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,9 +1,9 @@
 ja:
   field_displayname: 表示名
-  field_issues_private_by_default: 新しいレポートはデフォルトで非公開
-  field_issue_notes_private_by_default: レポートの注記はデフォルトで非公開
-  field_warn_when_creating_public_issue: 公開レポートを作成する前に警告する
-  text_privacy_confirm_public: 本当に公開レポートを作成したいですか？
+  field_issues_private_by_default: 新しいチケットはデフォルトでプライベート
+  field_issue_notes_private_by_default: チケットのコメントはデフォルトでプライベート
+  field_warn_when_creating_public_issue: 公開チケットを作成する前に警告する
+  text_privacy_confirm_public: 本当に公開チケットを作成したいですか？
   label_privacy_display_settings: 表示設定
   label_privacy_displayname_fallback: "表示名が設定されていない場合、ユーザーの表示形式をフォールバックします。"
   label_privacy_displayname_info: "この設定は、グローバルな<em>ユーザーの表示形式</em>が表示名フィールドを使用するように設定されている場合にのみ関係しますが、現在はそうではありません。ユーザーの表示形式を変更するには、%{link}にアクセスしてください。"


### PR DESCRIPTION
Changes proposed in this pull request:
- Localizes permission labels
- Translates missing text strings

![Screenshot from 2021-11-05 01-27-44](https://user-images.githubusercontent.com/227762/140379692-819d0f17-9acf-4dfa-ae65-c54784f92a5c.png)

Please check the Japanese translation, because it may be strange. ;-)
