### PR TITLE
Replace removed jQuery api '.size()' to '.length'

### DIFF
--- a/app/views/redmine_privacy/_issues_new_top_hook.html.erb
+++ b/app/views/redmine_privacy/_issues_new_top_hook.html.erb
@@ -2,7 +2,7 @@
   $(document).on('submit',
                  '#issue-form.new_issue',
                  function(event){
-                   var checked = $('#issue_is_private_wrap input:checked').size() == 1;
+                   var checked = $('#issue_is_private_wrap input:checked').length == 1;
                    if(!(checked || confirm('<%= j l :text_privacy_confirm_public %>'))) {
                      $(this).attr('data-submitted', null); // to allow resubmitting the form
                      event.preventDefault();


### PR DESCRIPTION
Fixes removed deprecated jQuery API (`.size()`) error after Redmine 5.0.
* [Feature #34337: Remove jQuery Migrate - Redmine](https://www.redmine.org/issues/34337)

Changes proposed in this pull request:
- Replace removed jQuery API '.size()` to `.length`.

@dkastl @mopinfish 
This is equivalent with the following Supply plugin's PR.
https://github.com/gtt-project/redmine_supply/pull/25 

And target branch is `main`, because `next` branch includes new permission for project members in summary.
